### PR TITLE
fix: fall back to powerUserSettings.persona_description for userDesc

### DIFF
--- a/index.js
+++ b/index.js
@@ -3611,7 +3611,7 @@ function resolveChatProfileContext(ctx = getContext()) {
     return {
         isGroup,
         userName: String(ctx.name1 || "").trim() || "user",
-        userDesc: String(ctx.persona || "").trim(),
+        userDesc: String(ctx.persona || ctx.powerUserSettings?.persona_description || "").trim(),
         charIds,
         charNames,
         charNameJoined: charNames.length ? charNames.join(", ") : "character",


### PR DESCRIPTION

Fixes #4 

## Problem

`{{userDesc}}` resolves to empty in SillyTavern 1.18.0 because `ctx.persona` is `undefined`. The persona description is stored in `power_user.persona_description`, accessible via `ctx.powerUserSettings?.persona_description`.

## Fix

In `resolveChatProfileContext()`, add `ctx.powerUserSettings?.persona_description` as a fallback when `ctx.persona` is empty:

```diff
- userDesc: String(ctx.persona || "").trim(),
+ userDesc: String(ctx.persona || ctx.powerUserSettings?.persona_description || "").trim(),
```

## Why This Works

- `getContext()` in `st-context.js` exposes `powerUserSettings: power_user` (direct reference)
- `power_user.persona_description` is populated by `selectCurrentPersona()` when a persona is active
- The optional chaining (`?.`) ensures no errors if `powerUserSettings` is missing

## Testing

1. Configure a persona with a description in ST 1.18.0
2. Set QIG custom instruction to `userDesc={{userDesc}}`
3. Trigger generation — `{{userDesc}}` should now resolve to the persona description