### PR TITLE
Fix gallery navigation arrows on SillyTavern 1.18.0

### DIFF
--- a/index.js
+++ b/index.js
@@ -7328,7 +7328,7 @@ async function insertImageIntoMessage(entryOrUrl, targetMessageIndex = null) {
 
         const messageElement = $(`.mes[mesid="${idx}"]`);
         if (messageElement.length) {
-            ctx.appendMediaToMessage(message, messageElement, 'keep');
+            ctx.appendMediaToMessage(message, messageElement, 'replace');
         }
     } else {
         // Legacy fallback for older ST versions


### PR DESCRIPTION
Fixes #7

## Problem

On SillyTavern 1.18.0 the gallery left/right arrows do nothing after generating multiple images in the same message.

## Root Cause

When inserting an image into an existing message, `insertImageIntoMessage` called:

```js
ctx.appendMediaToMessage(message, messageElement, 'keep');
```

The `'keep'` mode tells SillyTavern core to skip DOM updates when the message already has a media container. As a result:

- The newly pushed image entry in `message.extra.media` is correctly persisted to the chat file.
- The gallery arrows have multiple images to navigate between in the data model.
- But the DOM is never updated — only the very first image is ever rendered, and the arrows have no effect.

## Fix

Switch the mode from `'keep'` to `'replace'`:

```js
ctx.appendMediaToMessage(message, messageElement, 'replace');
```

`'replace'` forces SillyTavern to fully re-render the media container with the current `message.extra.media` array and the correct `media_index`, which natively enables left/right gallery navigation.

## Testing

1. Generate multiple images in the same message (or generate, then use the palette generate button on that message).
2. Left and right gallery arrows should now correctly navigate between all generated images.
3. `message.extra.media` should accumulate all images across generations as before.